### PR TITLE
Implement WithError on Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,23 @@ func (s *S) Foo() {
 }
 ```
 
+#### WithError
+creates an entry from the standard logger with the error content as a field.
+
+```go
+package main
+
+import (
+	"github.com/americanas-go/log/contrib/sirupsen/logrus.v1"
+)
+
+func main() {
+	logrus.NewLogger()
+	log.WithError(errors.New("something bad")).
+		Info("main method.")
+}
+```
+
 #### ToContext
 sends the state of the instance to the context.
 

--- a/contrib/go.uber.org/zap.v1/README.md
+++ b/contrib/go.uber.org/zap.v1/README.md
@@ -73,6 +73,7 @@ default options:
 | FileCompress  | true |
 | FileMaxAge  | 28 |
 | FileFormatter  | "TEXT" |
+| ErrorFieldName | "err" |
 
 The package accepts a default constructor:
 ```go
@@ -215,4 +216,10 @@ logger := zap.NewLogger(zap.WithFileFormatter("TEXT"))
 
 // json formatter
 logger := zap.NewLogger(zap.WithFileFormatter("JSON"))
+```
+
+##### WithErrorFieldName
+sets the field name used on `WithError`
+```go
+logger := zap.NewLogger(zap.WithErrorFieldName("error"))
 ```

--- a/contrib/go.uber.org/zap.v1/logger.go
+++ b/contrib/go.uber.org/zap.v1/logger.go
@@ -352,10 +352,12 @@ func fieldsFromContext(ctx context.Context) log.Fields {
 }
 
 func mapToSlice(m log.Fields) []interface{} {
-	var f = make([]interface{}, 0)
+	f := make([]interface{}, 2*len(m))
+	i := 0
 	for k, v := range m {
-		f = append(f, k)
-		f = append(f, v)
+		f[i] = k
+		f[i+1] = v
+		i = i + 2
 	}
 
 	return f

--- a/contrib/go.uber.org/zap.v1/logger.go
+++ b/contrib/go.uber.org/zap.v1/logger.go
@@ -29,6 +29,7 @@ const (
 	defaultFileCompress            = true
 	defaultFileMaxAge              = 28
 	defaultFileFormatter           = "TEXT"
+	defaultErrorFieldName          = "err"
 )
 
 // NewLogger constructs a new Logger from provided variadic Option.
@@ -75,11 +76,20 @@ func NewLoggerWithOptions(options *Options) log.Logger {
 	// logged will always be the wrapped file. In our case zap.go
 	zaplogger := newSugaredLogger(combinedCore)
 
+	// Default options are only applied if this is called via NewLogger
+	// If called direct, the options passed to this function may be empty.
+	// Hence the default is reinforced here.
+	errorField := options.ErrorFieldName
+	if errorField == "" {
+		errorField = defaultErrorFieldName
+	}
+
 	newlogger := &zapLogger{
-		fields:        log.Fields{},
-		sugaredLogger: zaplogger,
-		writers:       writers,
-		core:          combinedCore,
+		fields:         log.Fields{},
+		sugaredLogger:  zaplogger,
+		writers:        writers,
+		core:           combinedCore,
+		errorFieldName: errorField,
 	}
 
 	log.NewLogger(newlogger)
@@ -88,6 +98,8 @@ func NewLoggerWithOptions(options *Options) log.Logger {
 
 func defaultOptions() *Options {
 	return &Options{
+		ErrorFieldName: defaultErrorFieldName,
+
 		Console: struct {
 			Enabled   bool
 			Level     string
@@ -167,10 +179,11 @@ func logLevel(level string) zapcore.Level {
 }
 
 type zapLogger struct {
-	sugaredLogger *zap.SugaredLogger
-	fields        log.Fields
-	writers       []io.Writer
-	core          zapcore.Core
+	sugaredLogger  *zap.SugaredLogger
+	fields         log.Fields
+	writers        []io.Writer
+	core           zapcore.Core
+	errorFieldName string
 }
 
 // Printf uses (*zap.SugaredLogger).Infof to log a templated message.
@@ -229,7 +242,7 @@ func (l *zapLogger) WithField(key string, value interface{}) log.Logger {
 
 	f := mapToSlice(newFields)
 	newLogger := newSugaredLogger(l.core).With(f...)
-	return &zapLogger{newLogger, newFields, l.writers, l.core}
+	return &zapLogger{newLogger, newFields, l.writers, l.core, l.errorFieldName}
 }
 
 // Output returns a Writer that represents the zap writers.
@@ -281,7 +294,7 @@ func (l *zapLogger) WithFields(fields log.Fields) log.Logger {
 
 	f := mapToSlice(newFields)
 	newLogger := newSugaredLogger(l.core).With(f...)
-	return &zapLogger{newLogger, newFields, l.writers, l.core}
+	return &zapLogger{newLogger, newFields, l.writers, l.core, l.errorFieldName}
 }
 
 // WithTypeOf adds type and package information fields.
@@ -293,6 +306,10 @@ func (l *zapLogger) WithTypeOf(obj interface{}) log.Logger {
 		"reflect.type.name":    t.Name(),
 		"reflect.type.package": t.PkgPath(),
 	})
+}
+
+func (l *zapLogger) WithError(err error) log.Logger {
+	return l.WithField(l.errorFieldName, err.Error())
 }
 
 func (l *zapLogger) Fields() log.Fields {

--- a/contrib/go.uber.org/zap.v1/options.go
+++ b/contrib/go.uber.org/zap.v1/options.go
@@ -16,9 +16,17 @@ type Options struct {
 		MaxAge    int    // file max age
 		Formatter string // file formatter TEXT/JSON
 	}
+
+	ErrorFieldName string // define field name for error logging
 }
 
 type Option func(options *Options)
+
+func WithErrorFieldName(value string) Option {
+	return func(options *Options) {
+		options.ErrorFieldName = value
+	}
+}
 
 func WithConsoleEnabled(value bool) Option {
 	return func(options *Options) {

--- a/contrib/go.uber.org/zap.v1/options_test.go
+++ b/contrib/go.uber.org/zap.v1/options_test.go
@@ -89,6 +89,12 @@ func (s *OptionsSuite) TestOptionsWithMethods() {
 			got:    func(o *Options) interface{} { return o.File.Formatter },
 			method: WithFileFormatter("TEXT"),
 		},
+		{
+			name:   "Options with custom error field name",
+			want:   "error",
+			got:    func(o *Options) interface{} { return o.ErrorFieldName },
+			method: WithErrorFieldName("error"),
+		},
 	}
 
 	for _, t := range tt {

--- a/contrib/rs/zerolog.v1/README.md
+++ b/contrib/rs/zerolog.v1/README.md
@@ -71,6 +71,7 @@ default options:
 | FileMaxSize  | 100  |
 | FileCompress  | true  |
 | FileMaxAge  | 28  |
+| ErrorFieldName | "err" | 
 
 The package accepts a default constructor:
 ```go
@@ -182,4 +183,10 @@ sets the maximum number of days to retain old log files based on the timestamp e
 ```go
 // file max age
 logger := zerolog.NewLogger(zerolog.WithFileMaxAge(10))
+```
+
+##### WithErrorFieldName
+sets the field name used on `WithError`
+```go
+logger := zerolog.NewLogger(zerolog.WithErrorFieldName("error"))
 ```

--- a/contrib/rs/zerolog.v1/options.go
+++ b/contrib/rs/zerolog.v1/options.go
@@ -3,7 +3,8 @@ package zerolog
 type Options struct {
 	Formatter string // formatter TEXT/JSON
 	Level     string // log level
-	Console   struct {
+
+	Console struct {
 		Enabled bool // enable/disable console logging
 	}
 	File struct {
@@ -14,9 +15,17 @@ type Options struct {
 		Compress bool   // enabled/disable file compress
 		MaxAge   int    // file max age
 	}
+
+	ErrorFieldName string // define field name for error logging
 }
 
 type Option func(options *Options)
+
+func WithErrorFieldName(value string) Option {
+	return func(options *Options) {
+		options.ErrorFieldName = value
+	}
+}
 
 func WithFormatter(value string) Option {
 	return func(options *Options) {

--- a/contrib/rs/zerolog.v1/options_test.go
+++ b/contrib/rs/zerolog.v1/options_test.go
@@ -77,6 +77,12 @@ func (s *OptionsSuite) TestOptionsWithMethods() {
 			got:    func(o *Options) interface{} { return o.Formatter },
 			method: WithFormatter("JSON"),
 		},
+		{
+			name:   "Options with error field name",
+			want:   "error",
+			got:    func(o *Options) interface{} { return o.ErrorFieldName },
+			method: WithErrorFieldName("error"),
+		},
 	}
 
 	for _, t := range tt {

--- a/contrib/sirupsen/logrus.v1/README.md
+++ b/contrib/sirupsen/logrus.v1/README.md
@@ -73,6 +73,7 @@ default options:
 | FileCompress | true |
 | FileMaxAge | 28 |
 | TimeFormat | "2006/01/02 15:04:05.000" |
+| ErrorFieldName | "err" | 
 
 The package accepts a default constructor:
 ```go
@@ -219,4 +220,10 @@ sets the maximum number of days to retain old log files based on the timestamp e
 ```go
 // file max age
 logger := logrus.NewLogger(logrus.WithFileMaxAge(10))
+```
+
+##### WithErrorFieldName
+sets the field name used on `WithError`
+```go
+logger := logrus.NewLogger(logrus.WithErrorFieldName("error"))
 ```

--- a/contrib/sirupsen/logrus.v1/options.go
+++ b/contrib/sirupsen/logrus.v1/options.go
@@ -3,8 +3,9 @@ package logrus
 import "github.com/sirupsen/logrus"
 
 type Options struct {
-	Formatter logrus.Formatter // formatter TEXT/JSON/CLOUDWATCH
-	Time      struct {
+	Formatter      logrus.Formatter // formatter TEXT/JSON/CLOUDWATCH
+	ErrorFieldName string           // define field name for error logging
+	Time           struct {
 		Format string // date and time formats
 	}
 	Console struct {
@@ -24,6 +25,12 @@ type Options struct {
 }
 
 type Option func(options *Options)
+
+func WithErrorFieldName(value string) Option {
+	return func(options *Options) {
+		options.ErrorFieldName = value
+	}
+}
 
 func WithFormatter(value logrus.Formatter) Option {
 	return func(options *Options) {

--- a/contrib/sirupsen/logrus.v1/options_test.go
+++ b/contrib/sirupsen/logrus.v1/options_test.go
@@ -90,6 +90,12 @@ func (s *OptionsSuite) TestOptionsWithMethods() {
 			got:    func(o *Options) interface{} { return o.Time.Format },
 			method: WithTimeFormat("2006"),
 		},
+		{
+			name:   "Options with custom error field name",
+			want:   "error",
+			got:    func(o *Options) interface{} { return o.ErrorFieldName },
+			method: WithErrorFieldName("error"),
+		},
 	}
 
 	for _, t := range tt {

--- a/logger.go
+++ b/logger.go
@@ -44,6 +44,8 @@ type Logger interface {
 
 	WithField(key string, value interface{}) Logger
 
+	WithError(err error) Logger
+
 	WithTypeOf(obj interface{}) Logger
 
 	ToContext(ctx context.Context) context.Context

--- a/wrapper.go
+++ b/wrapper.go
@@ -100,6 +100,11 @@ func WithField(key string, value string) Logger {
 	return l.WithField(key, value)
 }
 
+// WithError adds an error as a field to logger
+func WithError(err error) Logger {
+	return l.WithError(err)
+}
+
 // WithFields adds fields to logger.
 func WithFields(keyValues Fields) Logger {
 	return l.WithFields(keyValues)

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -334,6 +334,22 @@ func (_m *LoggerMock) Warnf(format string, args ...interface{}) {
 	_m.Called(_ca...)
 }
 
+// WithError provides a mock function with given fields: err
+func (_m *LoggerMock) WithError(err error) Logger {
+	ret := _m.Called(err)
+
+	var r0 Logger
+	if rf, ok := ret.Get(0).(func(error) Logger); ok {
+		r0 = rf(err)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(Logger)
+		}
+	}
+
+	return r0
+}
+
 // WithField provides a mock function with given fields: key, value
 func (_m *LoggerMock) WithField(key string, value interface{}) Logger {
 	ret := _m.Called(key, value)


### PR DESCRIPTION
Closes #28.

This PR also improves the implementation of `mapToSlice` of the `zap` implementation.