### PR TITLE
Use NoOp implementation of Logger for package-level functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,34 @@ func withoutContext() {
 }
 ```
 
+Global Logger
+--------
+The `americanas-go/log` provides top level logging function, however by default they do nothing (NoOp). You can define your global logger, after you instantiate the desired implementation, by using the `log.SetGlobalLogger`.
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/americanas-go/log"
+
+	//"github.com/americanas-go/log/contrib/go.uber.org/zap.v1"
+	//"github.com/americanas-go/log/contrib/rs/zerolog.v1"
+	"github.com/americanas-go/log/contrib/sirupsen/logrus.v1"
+)
+
+func main() {
+	//logger := zap.NewLogger()
+	//logger := zerolog.NewLogger()
+	logger := logrus.NewLogger()
+	log.SetGlobalLogger(logger)
+
+	log.Info("main method.")
+}
+```
+
+
 Logger
 --------
 Logger is the contract for the logging.

--- a/contrib/go.uber.org/zap.v1/logger.go
+++ b/contrib/go.uber.org/zap.v1/logger.go
@@ -92,7 +92,6 @@ func NewLoggerWithOptions(options *Options) log.Logger {
 		errorFieldName: errorField,
 	}
 
-	log.NewLogger(newlogger)
 	return newlogger
 }
 

--- a/contrib/rs/zerolog.v1/logger.go
+++ b/contrib/rs/zerolog.v1/logger.go
@@ -44,7 +44,7 @@ func NewLoggerWithOptions(options *Options) log.Logger {
 			logger: zerologger,
 		}
 
-		log.NewLogger(logger)
+		log.SetGlobalLogger(logger)
 		return logger
 	}
 
@@ -70,7 +70,7 @@ func NewLoggerWithOptions(options *Options) log.Logger {
 		errorFieldName: errorField,
 	}
 
-	log.NewLogger(logger)
+	log.SetGlobalLogger(logger)
 	return logger
 }
 

--- a/contrib/sirupsen/logrus.v1/logger.go
+++ b/contrib/sirupsen/logrus.v1/logger.go
@@ -93,7 +93,7 @@ func NewLoggerWithOptions(options *Options) log.Logger {
 		errorFieldName: errorField,
 	}
 
-	log.NewLogger(logger)
+	log.SetGlobalLogger(logger)
 	return logger
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ExampleNewLogger() {
-	log.NewLogger(logrus.NewLogger(logrus.WithFormatter(text.New(text.WithDisableTimestamp(true)))))
+	log.SetGlobalLogger(logrus.NewLogger(logrus.WithFormatter(text.New(text.WithDisableTimestamp(true)))))
 	log.WithField("main_field", "example")
 	log.Info("main method.")
 	// Output: level=info msg="main method."
@@ -39,7 +39,7 @@ func ExampleToContext() {
 	}
 
 	ctx := context.Background()
-	log.NewLogger(logrus.NewLogger(
+	log.SetGlobalLogger(logrus.NewLogger(
 		logrus.WithFormatter(text.New(text.WithDisableTimestamp(true))),
 	).WithField("main_field", "example"))
 
@@ -79,7 +79,7 @@ func ExampleFromContext() {
 	}
 
 	ctx := context.Background()
-	log.NewLogger(logrus.NewLogger(
+	log.SetGlobalLogger(logrus.NewLogger(
 		logrus.WithFormatter(text.New(text.WithDisableTimestamp(true))),
 	).WithField("main_field", "example"))
 

--- a/noop.go
+++ b/noop.go
@@ -1,0 +1,60 @@
+package log
+
+import (
+	"context"
+	"io"
+)
+
+// Noop is a dummy implementation of Logger
+type Noop struct{}
+
+// NewNoop create a Noop Logger
+func NewNoop() Noop {
+	return Noop{}
+}
+
+func (n Noop) Printf(format string, args ...interface{}) {}
+
+func (n Noop) Tracef(format string, args ...interface{}) {}
+
+func (n Noop) Trace(args ...interface{}) {}
+
+func (n Noop) Debugf(format string, args ...interface{}) {}
+
+func (n Noop) Debug(args ...interface{}) {}
+
+func (n Noop) Infof(format string, args ...interface{}) {}
+
+func (n Noop) Info(args ...interface{}) {}
+
+func (n Noop) Warnf(format string, args ...interface{}) {}
+
+func (n Noop) Warn(args ...interface{}) {}
+
+func (n Noop) Errorf(format string, args ...interface{}) {}
+
+func (n Noop) Error(args ...interface{}) {}
+
+func (n Noop) Fatalf(format string, args ...interface{}) {}
+
+func (n Noop) Fatal(args ...interface{}) {}
+
+func (n Noop) Panicf(format string, args ...interface{}) {}
+
+func (n Noop) Panic(args ...interface{}) {}
+
+func (n Noop) WithFields(keyValues Fields) Logger { return n }
+
+func (n Noop) WithField(key string, value interface{}) Logger { return n }
+
+func (n Noop) WithError(err error) Logger { return n }
+
+func (n Noop) WithTypeOf(obj interface{}) Logger { return n }
+
+func (n Noop) ToContext(ctx context.Context) context.Context { return ctx }
+
+func (n Noop) FromContext(ctx context.Context) Logger { return n }
+
+func (n Noop) Output() io.Writer { return io.Discard }
+
+func (n Noop) Fields() Fields { return Fields{} }

--- a/wrapper.go
+++ b/wrapper.go
@@ -1,10 +1,26 @@
 package log
 
+import (
+	"sync"
+)
+
 // A global variable so that l functions can be directly accessed.
-var l Logger
+var (
+	l  Logger = Noop{}
+	mu sync.RWMutex
+)
 
 // NewLogger returns an instance of logger.
+// Deprecated: prefer SetGlobalLogger
 func NewLogger(logger Logger) {
+	mu.Lock()
+	defer mu.Unlock()
+	l = logger
+}
+
+func SetGlobalLogger(logger Logger) {
+	mu.Lock()
+	defer mu.Unlock()
 	l = logger
 }
 
@@ -12,6 +28,9 @@ func NewLogger(logger Logger) {
 //
 // For templating details see implementation doc.
 func Printf(format string, args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Printf(format, args...)
 }
 
@@ -19,11 +38,17 @@ func Printf(format string, args ...interface{}) {
 //
 // For templating details see implementation doc.
 func Tracef(format string, args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Tracef(format, args...)
 }
 
 // Trace logs a message at trace level.
 func Trace(args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Trace(args...)
 }
 
@@ -31,11 +56,17 @@ func Trace(args ...interface{}) {
 //
 // For templating details see implementation doc.
 func Debugf(format string, args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Debugf(format, args...)
 }
 
 // Debug logs a message at debug level.
 func Debug(args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Debug(args...)
 }
 
@@ -43,11 +74,17 @@ func Debug(args ...interface{}) {
 //
 // For templating details see implementation doc.
 func Infof(format string, args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Infof(format, args...)
 }
 
 // Info logs a message at info level.
 func Info(args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Info(args...)
 }
 
@@ -55,11 +92,17 @@ func Info(args ...interface{}) {
 //
 // For templating details see implementation doc.
 func Warnf(format string, args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Warnf(format, args...)
 }
 
 // Warn logs a message at warn level.
 func Warn(args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Warn(args...)
 }
 
@@ -67,55 +110,88 @@ func Warn(args ...interface{}) {
 //
 // For templating details see implementation doc.
 func Errorf(format string, args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Errorf(format, args...)
 }
 
 // Error logs a message at error level.
 func Error(args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Error(args...)
 }
 
 // Panicf is equivalent to Printf() followed by a call to panic().
 func Panicf(format string, args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Panicf(format, args...)
 }
 
 // Panic is equivalent to Print() followed by a call to panic().
 func Panic(args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Panic(args...)
 }
 
 // Fatal is equivalent to Print() followed by a call to os.Exit(1).
 func Fatal(args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Fatal(args...)
 }
 
 // Fatalf is equivalent to Printf() followed by a call to os.Exit(1).
 func Fatalf(format string, args ...interface{}) {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	l.Fatalf(format, args...)
 }
 
 // WithField adds a key and value to logger.
 func WithField(key string, value string) Logger {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	return l.WithField(key, value)
 }
 
 // WithError adds an error as a field to logger
 func WithError(err error) Logger {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	return l.WithError(err)
 }
 
 // WithFields adds fields to logger.
 func WithFields(keyValues Fields) Logger {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	return l.WithFields(keyValues)
 }
 
 // WithTypeOf adds type information to logger.
 func WithTypeOf(obj interface{}) Logger {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	return l.WithTypeOf(obj)
 }
 
 // GetLogger returns instance of Logger.
 func GetLogger() Logger {
+	mu.RLock()
+	defer mu.RUnlock()
+
 	return l
 }

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"context"
+	"errors"
 	"io"
 	"reflect"
 	"testing"
@@ -93,6 +94,13 @@ func (s *WrapperSuite) TestWrapperWrappedMethods() {
 			method: func() { WithField("key", "value") },
 		},
 		{
+			name: "WithError",
+			mock: func(l *LoggerMock) {
+				l.On("WithError", mock.Anything, mock.Anything).Times(1).Return(l)
+			},
+			method: func() { WithError(errors.New("something bad")) },
+		},
+		{
 			name: "WithFields",
 			mock: func(l *LoggerMock) {
 				l.On("WithFields", mock.Anything).Times(1).Return(l)
@@ -123,7 +131,7 @@ func (s *WrapperSuite) TestWrapperWrappedMethods() {
 			} else {
 				t.mock(l)
 			}
-			NewLogger(l)
+			SetGlobalLogger(l)
 			t.method()
 			l.AssertExpectations(s.T())
 		})
@@ -144,7 +152,7 @@ func (s *WrapperSuite) TestWrapperGetLogger() {
 
 	for _, t := range tt {
 		s.Run(t.name, func() {
-			NewLogger(t.want)
+			SetGlobalLogger(t.want)
 			got := GetLogger()
 			s.Assert().True(reflect.DeepEqual(got, t.want), "got  %v\nwant %v", got, t.want)
 		})


### PR DESCRIPTION
This PR closes #31.

Although the proposed solution was to use `zap` implementation as default, methods like `WithField(key string, value interface{}) log.Logger` demands that the `zap` package depends on the top-level `log` package, hence there is no way to avoid a circular dependency between the two.

There is no workaround for this because the Go type system is *invariant*. You can read more about this [here](https://eli.thegreenplace.net/2021/go-internals-invariance-and-memory-layout-of-slices/) or test in this playground that I made: https://play.golang.org/p/YpTQKHsjbGq

Therefore, I resort to implement a `NoOp` logger and use it as default. This PR also introduces `log.SetGlobalLogger` and marks `log.NewLogger` as deprecated. I notice that the implementation packages called `log.NewLogger` at the end of the factory functions. I changed to use the new function, however, this should be removed in a v2 since factory functions should not have side effects. Finally, it also makes all package-level functions concurrent-safe.
