### PR TITLE
Custom output zap logger

### DIFF
--- a/contrib/go.uber.org/zap.v1/logger_test.go
+++ b/contrib/go.uber.org/zap.v1/logger_test.go
@@ -3,6 +3,7 @@ package zap
 import (
 	//"github.com/stretchr/testify/mock"
 
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -27,6 +28,7 @@ func TestLoggerSuite(t *testing.T) {
 }
 
 func (s *LoggerSuite) TestNewLogger() {
+	buf := bytes.NewBuffer(nil)
 
 	tt := []struct {
 		name string
@@ -86,6 +88,23 @@ func (s *LoggerSuite) TestNewLogger() {
 			},
 			opts: []Option{
 				WithErrorFieldName("error"),
+			},
+		},
+		{
+			name: "New Logger with custom output",
+			want: func() log.Logger {
+				opts := defaultOptions()
+				opts.CustomOutput.Enabled = true
+				opts.CustomOutput.Formatter = "JSON"
+				opts.CustomOutput.Level = "TRACE"
+				opts.CustomOutput.Writer = buf
+				return NewLoggerWithOptions(opts)
+			},
+			opts: []Option{
+				WithCustomOutputEnabled(true),
+				WithCustomOutputFormatter("JSON"),
+				WithCustomOutputLevel("TRACE"),
+				WithCustomOutputWriter(buf),
 			},
 		},
 	}
@@ -185,76 +204,79 @@ func (s *LoggerSuite) TestLogger() {
 		{
 			name:   "logger Printf method",
 			method: "Printf",
-			want:   "info\treflect/value.go:337\tBlah",
+			want:   "info\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Trace method",
 			method: "Trace",
-			want:   "debug\treflect/value.go:337\tBlah",
+			want:   "debug\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Tracef method",
 			method: "Tracef",
-			want:   "debug\treflect/value.go:337\tBlah",
+			want:   "debug\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Debug method",
 			method: "Debug",
-			want:   "debug\treflect/value.go:337\tBlah",
+			want:   "debug\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Debugf method",
 			method: "Debugf",
-			want:   "debug\treflect/value.go:337\tBlah",
+			want:   "debug\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Info method",
 			method: "Info",
-			want:   "info\treflect/value.go:337\tBlah",
+			want:   "info\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Infof method",
 			method: "Infof",
-			want:   "info\treflect/value.go:337\tBlah",
+			want:   "info\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Warn method",
 			method: "Warn",
-			want:   "warn\treflect/value.go:337\tBlah",
+			want:   "warn\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Warnf method",
 			method: "Warnf",
-			want:   "warn\treflect/value.go:337\tBlah",
+			want:   "warn\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Error method",
 			method: "Error",
-			want:   "error\treflect/value.go:337\tBlah",
+			want:   "error\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Errorf method",
 			method: "Errorf",
-			want:   "error\treflect/value.go:337\tBlah",
+			want:   "error\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Panic method",
 			method: "Panic",
-			want:   "panic\treflect/value.go:337\tBlah",
+			want:   "panic\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Panicf method",
 			method: "Panicf",
-			want:   "panic\treflect/value.go:337\tBlah",
+			want:   "panic\treflect/value.go:339\tBlah",
 		},
 	}
 	for _, t := range tt {
 		s.Run(t.name, func() {
 			defer func() {
-				recover() //for panic case
+				//for panic case
+				recover()
+
 				got := captureLog(w, r)
-				s.Assert().True(strings.Contains(got, t.want), "got %v\nmust contain %v", got, t.want)
+				s.Assert().Contains(got, t.want)
 			}()
+
 			m := reflect.ValueOf(logger).MethodByName(t.method)
 			m.Call([]reflect.Value{reflect.ValueOf("Blah")})
 		})
@@ -270,12 +292,12 @@ func (s *LoggerSuite) TestLoggerFatal() {
 		{
 			name:   "logger Fatal method",
 			method: "Fatal",
-			want:   "fatal\treflect/value.go:337\tBlah",
+			want:   "fatal\treflect/value.go:339\tBlah",
 		},
 		{
 			name:   "logger Fatalf method",
 			method: "Fatalf",
-			want:   "fatal\treflect/value.go:337\tBlah",
+			want:   "fatal\treflect/value.go:339\tBlah",
 		},
 	}
 	for _, t := range tt {

--- a/contrib/go.uber.org/zap.v1/options.go
+++ b/contrib/go.uber.org/zap.v1/options.go
@@ -1,5 +1,7 @@
 package zap
 
+import "io"
+
 type Options struct {
 	Console struct {
 		Enabled   bool   // enable/disable console logging
@@ -15,6 +17,12 @@ type Options struct {
 		Compress  bool   // enabled/disable file compress
 		MaxAge    int    // file max age
 		Formatter string // file formatter TEXT/JSON
+	}
+	CustomOutput struct {
+		Writer    io.Writer // custom output writer
+		Enabled   bool      // enable/disable custom output logging
+		Level     string    // custom output log level
+		Formatter string    // custom output formatter TEXT/JSON
 	}
 
 	ErrorFieldName string // define field name for error logging
@@ -91,5 +99,29 @@ func WithFileMaxAge(value int) Option {
 func WithFileFormatter(value string) Option {
 	return func(options *Options) {
 		options.File.Formatter = value
+	}
+}
+
+func WithCustomOutputWriter(value io.Writer) Option {
+	return func(options *Options) {
+		options.CustomOutput.Writer = value
+	}
+}
+
+func WithCustomOutputEnabled(value bool) Option {
+	return func(options *Options) {
+		options.CustomOutput.Enabled = value
+	}
+}
+
+func WithCustomOutputLevel(value string) Option {
+	return func(options *Options) {
+		options.CustomOutput.Level = value
+	}
+}
+
+func WithCustomOutputFormatter(value string) Option {
+	return func(options *Options) {
+		options.CustomOutput.Formatter = value
 	}
 }

--- a/contrib/go.uber.org/zap.v1/options_test.go
+++ b/contrib/go.uber.org/zap.v1/options_test.go
@@ -1,7 +1,7 @@
 package zap
 
 import (
-	"reflect"
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -95,6 +95,32 @@ func (s *OptionsSuite) TestOptionsWithMethods() {
 			got:    func(o *Options) interface{} { return o.ErrorFieldName },
 			method: WithErrorFieldName("error"),
 		},
+		{
+			name:   "Options with custom output writer",
+			want:   bytes.NewBuffer(nil),
+			got:    func(o *Options) interface{} { return o.CustomOutput.Writer },
+			method: WithCustomOutputWriter(bytes.NewBuffer(nil)),
+		},
+		{
+			name:   "Options with custom output enabled",
+			want:   true,
+			got:    func(o *Options) interface{} { return o.CustomOutput.Enabled },
+			method: WithCustomOutputEnabled(true),
+		},
+
+		{
+			name:   "Options with custom output level",
+			want:   "INFO",
+			got:    func(o *Options) interface{} { return o.CustomOutput.Level },
+			method: WithCustomOutputLevel("INFO"),
+		},
+
+		{
+			name:   "Options with custom output formatter",
+			want:   "JSON",
+			got:    func(o *Options) interface{} { return o.CustomOutput.Formatter },
+			method: WithCustomOutputFormatter("JSON"),
+		},
 	}
 
 	for _, t := range tt {
@@ -102,7 +128,7 @@ func (s *OptionsSuite) TestOptionsWithMethods() {
 			opts := defaultOptions()
 			t.method(opts)
 			got := t.got(opts)
-			s.Assert().True(reflect.DeepEqual(got, t.want), "got  %v\nwant %v", got, t.want)
+			s.Assert().EqualValues(t.want, got)
 		})
 	}
 }

--- a/contrib/sirupsen/logrus.v1/logger_test.go
+++ b/contrib/sirupsen/logrus.v1/logger_test.go
@@ -306,7 +306,6 @@ func (s *LoggerSuite) TestLoggerFatal() {
 
 func TestLoggerMethod(t *testing.T) {
 	method := os.Getenv("LOGGER_TEST_METHOD")
-	fmt.Println("Blah")
 	if method == "" {
 		return
 	}


### PR DESCRIPTION
Para alguns casos em testes onde era necessário validar se determinada mensagem foi ou não publicada no log, me deparei com a necessidade de checar essas situações.

Como solução, implementei uma nova option no zap logger para  poder receber um io.Writer genérico, que pode ser, nos cases de teste, um simples bytes.Buffer que possibilita a leitura posterior.  